### PR TITLE
README: Revise spelling and update list of functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small library for X window manipulation
 
 ## documentation
 
-Here is the full list of all the function you can use from `libwm`:
+Here is the full list of all the functions provided by `libwm`:
 
     wm_init_xcb();
     wm_kill_xcb();
@@ -33,13 +33,13 @@ now.
 ## installation
 
 `libwm` provides two files: libwm.a and wm.h.  
-You can build/install them as follow:
+You can build/install them as follows:
 
     $ make
     # make install
 
 The makefile supports 2 macros: DESTDIR and PREFIX.
 
-Then to link your program against it, compile it as follow:
+To link your program against it, compile it as follows:
 
     cc pgm.c -lwm -o pgm

--- a/README.md
+++ b/README.md
@@ -6,28 +6,30 @@ A small library for X window manipulation
 
 Here is the full list of all the functions provided by `libwm`:
 
-    wm_init_xcb();
-    wm_kill_xcb();
-    wm_is_alive(wid);
-    wm_is_ignored(wid);
-    wm_is_listable(wid, mask);
-    wm_is_mapped(wid);
-    wm_get_atom_string(wid, atom, **value);
-    wm_get_screen();
-    wm_get_windows(wid, **list);
-    wm_get_focus();
-    wm_get_attribute(wid, attr);
-    wm_get_cursor(mode, wid, *x, *y);
-    wm_set_border(width, color, wid);
-    wm_set_focus(wid);
-    wm_set_cursor(x, y, mode);
-    wm_set_override(wid, mode);
-    wm_teleport(wid, w, h, x, y);
-    wm_move(wid, mode, x, y);
-    wm_remap(wid, mode);
-    wm_resize(wid, mode, w, h);
-    wm_restack(wid, mode);
-    wm_reg_event(wid, mask);
+```c
+wm_init_xcb();
+wm_kill_xcb();
+wm_is_alive(wid);
+wm_is_ignored(wid);
+wm_is_listable(wid, mask);
+wm_is_mapped(wid);
+wm_get_atom_string(wid, atom, **value);
+wm_get_screen();
+wm_get_windows(wid, **list);
+wm_get_focus();
+wm_get_attribute(wid, attr);
+wm_get_cursor(mode, wid, *x, *y);
+wm_set_border(width, color, wid);
+wm_set_focus(wid);
+wm_set_cursor(x, y, mode);
+wm_set_override(wid, mode);
+wm_teleport(wid, w, h, x, y);
+wm_move(wid, mode, x, y);
+wm_remap(wid, mode);
+wm_resize(wid, mode, w, h);
+wm_restack(wid, mode);
+wm_reg_event(wid, mask);
+```
 
 Their usage is specified in the `wm.h` header file, as it is quite small for
 now.
@@ -44,4 +46,4 @@ The makefile supports 2 macros: DESTDIR and PREFIX.
 
 To link your program against it, compile it as follows:
 
-    cc pgm.c -lwm -o pgm
+    $ cc pgm.c -lwm -o pgm

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Here is the full list of all the functions provided by `libwm`:
     wm_is_ignored(wid);
     wm_is_listable(wid, mask);
     wm_is_mapped(wid);
-    wm_get_focus();
+    wm_get_atom_string(wid, atom, **value);
     wm_get_screen();
     wm_get_windows(wid, **list);
+    wm_get_focus();
     wm_get_attribute(wid, attr);
     wm_get_cursor(mode, wid, *x, *y);
     wm_set_border(width, color, wid);
@@ -26,6 +27,7 @@ Here is the full list of all the functions provided by `libwm`:
     wm_remap(wid, mode);
     wm_resize(wid, mode, w, h);
     wm_restack(wid, mode);
+    wm_reg_event(wid, mask);
 
 Their usage is specified in the `wm.h` header file, as it is quite small for
 now.

--- a/README.md
+++ b/README.md
@@ -6,30 +6,28 @@ A small library for X window manipulation
 
 Here is the full list of all the functions provided by `libwm`:
 
-```c
-wm_init_xcb();
-wm_kill_xcb();
-wm_is_alive(wid);
-wm_is_ignored(wid);
-wm_is_listable(wid, mask);
-wm_is_mapped(wid);
-wm_get_atom_string(wid, atom, **value);
-wm_get_screen();
-wm_get_windows(wid, **list);
-wm_get_focus();
-wm_get_attribute(wid, attr);
-wm_get_cursor(mode, wid, *x, *y);
-wm_set_border(width, color, wid);
-wm_set_focus(wid);
-wm_set_cursor(x, y, mode);
-wm_set_override(wid, mode);
-wm_teleport(wid, w, h, x, y);
-wm_move(wid, mode, x, y);
-wm_remap(wid, mode);
-wm_resize(wid, mode, w, h);
-wm_restack(wid, mode);
-wm_reg_event(wid, mask);
-```
+    wm_init_xcb();
+    wm_kill_xcb();
+    wm_is_alive(wid);
+    wm_is_ignored(wid);
+    wm_is_listable(wid, mask);
+    wm_is_mapped(wid);
+    wm_get_atom_string(wid, atom, **value);
+    wm_get_screen();
+    wm_get_windows(wid, **list);
+    wm_get_focus();
+    wm_get_attribute(wid, attr);
+    wm_get_cursor(mode, wid, *x, *y);
+    wm_set_border(width, color, wid);
+    wm_set_focus(wid);
+    wm_set_cursor(x, y, mode);
+    wm_set_override(wid, mode);
+    wm_teleport(wid, w, h, x, y);
+    wm_move(wid, mode, x, y);
+    wm_remap(wid, mode);
+    wm_resize(wid, mode, w, h);
+    wm_restack(wid, mode);
+    wm_reg_event(wid, mask);
 
 Their usage is specified in the `wm.h` header file, as it is quite small for
 now.


### PR DESCRIPTION
This PR fixes some grammar mistakes in the README and updates the list of functions to match the order of functions in the header file `wm.h`

This also adds C syntaxt highlighting for the function list and adds a `$` in front of the link instruction command like the build instructions
